### PR TITLE
Add bounces property

### DIFF
--- a/Example/UltraDrawerView/Sources/ShapeViewController/ShapeCell.swift
+++ b/Example/UltraDrawerView/Sources/ShapeViewController/ShapeCell.swift
@@ -51,7 +51,7 @@ final class ShapeCell: UITableViewCell {
     private func setupViews() {
         backgroundColor = .white
         
-        addSubview(shapeButton)
+        contentView.addSubview(shapeButton)
         shapeButton.addTarget(self, action: #selector(handleShapeButton), for: .touchUpInside)
         
         shapeButton.layer.addSublayer(shapeLayer)
@@ -59,12 +59,12 @@ final class ShapeCell: UITableViewCell {
         shapeLayer.lineJoin = .round
         updateShapeColors()
         
-        addSubview(titleLabel)
+        contentView.addSubview(titleLabel)
         titleLabel.font = .boldSystemFont(ofSize: UIFont.labelFontSize)
         titleLabel.numberOfLines = 0
         titleLabel.textColor = .black
         
-        addSubview(subtitleLabel)
+        contentView.addSubview(subtitleLabel)
         subtitleLabel.font = .systemFont(ofSize: UIFont.systemFontSize)
         subtitleLabel.numberOfLines = 0
         subtitleLabel.textColor = .darkGray
@@ -79,18 +79,18 @@ final class ShapeCell: UITableViewCell {
         shapeButton.translatesAutoresizingMaskIntoConstraints = false
         shapeButton.widthAnchor.constraint(equalToConstant: shapeSize).isActive = true
         shapeButton.heightAnchor.constraint(equalToConstant: shapeSize).isActive = true
-        shapeButton.topAnchor.constraint(equalTo: topAnchor, constant: inset).isActive = true
-        shapeButton.leftAnchor.constraint(equalTo: leftAnchor, constant: inset).isActive = true
+        shapeButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: inset).isActive = true
+        shapeButton.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: inset).isActive = true
         
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.leftAnchor.constraint(equalTo: shapeButton.rightAnchor, constant: inset).isActive = true
-        titleLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -inset).isActive = true
-        titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: inset).isActive = true
+        titleLabel.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -inset).isActive = true
+        titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: inset).isActive = true
         
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.leftAnchor.constraint(equalTo: shapeButton.rightAnchor, constant: inset).isActive = true
-        subtitleLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -inset).isActive = true
-        subtitleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -inset).isActive = true
+        subtitleLabel.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -inset).isActive = true
+        subtitleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -inset).isActive = true
         subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8).isActive = true
     }
     

--- a/Sources/DrawerView.swift
+++ b/Sources/DrawerView.swift
@@ -82,6 +82,13 @@ open class DrawerView: UIView {
     
     /// Indicates whether or not the drawer fades its content in bottom state
     public var shouldFadeInBottomState: Bool = true
+    
+    /// A Boolean value that controls whether the scroll view bounces past the edge of content and back again
+    public var bounces: Bool = true {
+        didSet {
+            snappingView.bounces = bounces
+        }
+    }
 
     public init(content: Content, headerView: UIView) {
         snappingView = SnappingView(content: content, headerView: headerView)

--- a/Sources/SnappingView.swift
+++ b/Sources/SnappingView.swift
@@ -46,6 +46,9 @@ open class SnappingView: UIView {
         }
     }
     
+    /// A Boolean value that controls whether the scroll view bounces past the edge of content and back again
+    open var bounces: Bool = true
+    
     public init(content: Content, headerView: UIView) {
         self.content = content
         self.headerView = headerView
@@ -218,13 +221,21 @@ open class SnappingView: UIView {
         guard let limits = anchorLimits else { return target }
         
         if target < limits.lowerBound {
-            let diff = limits.lowerBound - target
-            let dim = abs(limits.lowerBound)
-            return limits.lowerBound - rubberBandClamp(diff, dim: dim)
+            if bounces {
+                let diff = limits.lowerBound - target
+                let dim = abs(limits.lowerBound)
+                return limits.lowerBound - rubberBandClamp(diff, dim: dim)
+            } else {
+                return limits.lowerBound
+            }
         } else if target > limits.upperBound {
-            let diff = target - limits.upperBound
-            let dim = abs(bounds.height - limits.upperBound)
-            return limits.upperBound + rubberBandClamp(diff, dim: dim)
+            if bounces {
+                let diff = target - limits.upperBound
+                let dim = abs(bounds.height - limits.upperBound)
+                return limits.upperBound + rubberBandClamp(diff, dim: dim)
+            } else {
+                return limits.upperBound
+            }
         } else {
             return target
         }
@@ -343,7 +354,7 @@ extension SnappingView: DrawerViewContentListener {
             
             let newOrigin: CGFloat
             
-            if diff > 0 {
+            if diff > 0 && bounces {
                 newOrigin = origin + diff
             } else {
                 newOrigin = (origin + diff).clamped(to: limits)


### PR DESCRIPTION
In this PR I add `bounces` property to `DrawerView` so a user can disable bounce.

When `drawer.bounce = false` drawer immediately stop moving in the lowest position.
When `drawer.bounce = true` drawer stop moving in the lowest position using rubber band effect.

Also I've fixed a bug where tapping on shape doesn’t trigger spring animation.

**Demo of `drawer.bounce = false`**

https://user-images.githubusercontent.com/410293/104280207-9e383280-54bc-11eb-8ba6-4a0d8db94d8d.mov


**To discuss**
I noticed that rubber band effect works only when a user interacts with a header view. When a user drag content view it doesn't use rubber band effect. What do you think about it? Is it possible to fix it? I tried to use `clampTargetHeaderOrigin` method inside `drawerViewContentDidScroll` but it doesn’t work.


https://user-images.githubusercontent.com/410293/104280419-efe0bd00-54bc-11eb-88b4-af62768003d5.mov

